### PR TITLE
New configuration option FacterOptions

### DIFF
--- a/collectd_facter/__init__.py
+++ b/collectd_facter/__init__.py
@@ -18,8 +18,9 @@ import subprocess
 #   processes the collectd.conf configuration stanza for this plugin
 #
 def config(c):
-  global facterbin, facts, config
+  global facteroptions, facterbin, facts, config
   facterbin = 'facter'
+  facteroptions = ''
   facts = {}
 
   for ci in c.children:
@@ -55,6 +56,8 @@ def config(c):
     elif ci.key == 'Facter':
        facterbin = ci.values[0]
 
+    elif ci.key == 'FacterOptions':
+       facteroptions = ci.values[0]
 
 
 # -----------------------------------------------------------------------------
@@ -67,7 +70,7 @@ def read(data=None):
   env = os.environ.copy()
   env['FACTERLIB'] = '/etc/facter'
 
-  output = subprocess.Popen(([facterbin, '--json']+facts.keys()), 
+  output = subprocess.Popen(([facterbin, '--json', facteroptions]+facts.keys()), 
 stdout=subprocess.PIPE, env=env)
   output.wait()
   output = output.stdout.read()

--- a/contrib/collect-facter.conf.example
+++ b/contrib/collect-facter.conf.example
@@ -13,6 +13,7 @@
     Fact "uptime_seconds" "uptime"
     FactFile "/etc/collectd-facter.list"
     Facter "/opt/puppetlabs/puppet/bin/facter"
+    FacterOptions "-p"
   </Module>
 </Plugin>
 


### PR DESCRIPTION
If FacterOptions is set it will add these additional options
to the facter command line. The classic use case is to
add `-p` to facter command line to load puppet facts.